### PR TITLE
fix(binary): download unarchived binaries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,3 +60,11 @@ jobs:
           tarball_binary_path: "aws-nuke-${version}-linux-amd64"
           smoke_test: "${binary} version"
           binary_new_name: "aws-nuke"
+
+      - name: Test downloading external unarchived binary
+        uses: ./
+        with:
+          binary: "vendir"
+          version: "0.40.2"
+          download_url: "https://github.com/carvel-dev/vendir/releases/download/v${version}/vendir-linux-amd64"
+          smoke_test: "${binary} --version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix regression in handling unarchived downloads.
+
 ## [3.1.0] - 2025-08-04
 
 ### Added

--- a/dist/index.js
+++ b/dist/index.js
@@ -29727,21 +29727,23 @@ module.exports = parseParams
 /******/ 
 /************************************************************************/
 var __webpack_exports__ = {};
-/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(7484);
-/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5236);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(3472);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(6928);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(7484);
+/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(5236);
+/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(3472);
+
 
 
 
 
 const run = async () => {
   try {
-    const binary = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('binary');
-    const version = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('version');
-    const binaryNewName = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('binary_new_name');
-    let downloadURL = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('download_url');
-    let tarballBinaryPath = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('tarball_binary_path');
-    let smokeTest = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('smoke_test');
+    const binary = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput('binary');
+    const version = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput('version');
+    const binaryNewName = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput('binary_new_name');
+    let downloadURL = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput('download_url');
+    let tarballBinaryPath = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput('tarball_binary_path');
+    let smokeTest = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput('smoke_test');
 
     const fillTemplate = str => 
       str
@@ -29752,20 +29754,20 @@ const run = async () => {
     tarballBinaryPath = fillTemplate(tarballBinaryPath)
     smokeTest = fillTemplate(smokeTest);
 
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`binary:               ${binary}`);
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`binary:               ${binary}`);
     if (binaryNewName) {
-      _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`binaryNewName:        ${binaryNewName}`);
+      _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`binaryNewName:        ${binaryNewName}`);
     }
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`download URL:         ${downloadURL}`)
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`tarball binary path:  ${tarballBinaryPath}`)
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`smoke test:           ${smokeTest}`)
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`download URL:         ${downloadURL}`)
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`tarball binary path:  ${tarballBinaryPath}`)
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`smoke test:           ${smokeTest}`)
 
     const stripComponents = tarballBinaryPath.split("/").length - 1;
 
     await installTool(binary, version, downloadURL, stripComponents, tarballBinaryPath, binaryNewName);
-    await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec(smokeTest);
+    await _actions_exec__WEBPACK_IMPORTED_MODULE_2__.exec(smokeTest);
   } catch (error) {
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(error.message);
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(error.message);
   }
 }
 
@@ -29778,19 +29780,27 @@ const getUnTarCommand = (name, path, stripComponents, wildcard, binaryNewName) =
 }
 
 const installTool = async (name, version, url, stripComponents, wildcard, binaryNewName) => {
-  let cachedPath = _actions_tool_cache__WEBPACK_IMPORTED_MODULE_2__.find(name, version);
+  let cachedPath = _actions_tool_cache__WEBPACK_IMPORTED_MODULE_3__.find(name, version);
   if (cachedPath) {
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.addPath(cachedPath);
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.addPath(cachedPath);
     return
   }
 
-  const path = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_2__.downloadTool(url);
-  await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec(`mkdir ${name}`);
-  const unTarCommand = getUnTarCommand(name, path, stripComponents, wildcard, binaryNewName);
-  await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec(`${unTarCommand}`);
+  const path = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_3__.downloadTool(url);
+  await _actions_exec__WEBPACK_IMPORTED_MODULE_2__.exec(`mkdir ${name}`);
 
-  cachedPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_2__.cacheDir(name, name, version);
-  _actions_core__WEBPACK_IMPORTED_MODULE_0__.addPath(cachedPath);
+  if (path__WEBPACK_IMPORTED_MODULE_0__.extname(url) === '') {
+    // If there is not extension, assume this is an unarchived binary.
+    await _actions_exec__WEBPACK_IMPORTED_MODULE_2__.exec(`mv "${path}" "${name}/${name}"`);
+    await _actions_exec__WEBPACK_IMPORTED_MODULE_2__.exec(`chmod +x "${name}/${name}"`);
+  } else {
+    const unTarCommand = getUnTarCommand(name, path, stripComponents, wildcard, binaryNewName);
+    await _actions_exec__WEBPACK_IMPORTED_MODULE_2__.exec(`${unTarCommand}`);
+  }
+
+  cachedPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_3__.cacheDir(name, name, version);
+  _actions_core__WEBPACK_IMPORTED_MODULE_1__.addPath(cachedPath);
 }
 
 run();
+

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import paths from 'path';
 import core from '@actions/core';
 import exec from '@actions/exec';
 import tc from '@actions/tool-cache';

--- a/index.js
+++ b/index.js
@@ -54,8 +54,15 @@ const installTool = async (name, version, url, stripComponents, wildcard, binary
 
   const path = await tc.downloadTool(url);
   await exec.exec(`mkdir ${name}`);
-  const unTarCommand = getUnTarCommand(name, path, stripComponents, wildcard, binaryNewName);
-  await exec.exec(`${unTarCommand}`);
+
+  if (paths.extname(url) === '') {
+    // If there is not extension, assume this is an unarchived binary.
+    await exec.exec(`mv "${path}" "${name}/${name}"`);
+    await exec.exec(`chmod +x "${name}/${name}"`);
+  } else {
+    const unTarCommand = getUnTarCommand(name, path, stripComponents, wildcard, binaryNewName);
+    await exec.exec(`${unTarCommand}`);
+  }
 
   cachedPath = await tc.cacheDir(name, name, version);
   core.addPath(cachedPath);


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

The bug was introduced in https://github.com/giantswarm/install-binary-action/pull/236, causing downloading unarchived binaries to fail.

In this PR I'm restoring the test case and the code we had before.