### PR TITLE
Fix mkdir collision when binary name matches a workspace entry

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,3 +68,29 @@ jobs:
           version: "0.40.2"
           download_url: "https://github.com/carvel-dev/vendir/releases/download/v${version}/vendir-linux-amd64"
           smoke_test: "${binary} --version"
+
+      # Regression test for https://github.com/giantswarm/install-binary-action/issues/334
+      # Earlier versions ran `mkdir <binary>` in the workspace and failed when
+      # a file or directory with the same name was already checked out.
+      - name: Pre-create colliding workspace entries (regression for #334)
+        run: |
+          mkdir -p helm
+          touch jq
+      - name: Test tarball install with colliding workspace directory
+        uses: ./
+        with:
+          binary: helm
+          version: "3.17.3"
+          download_url: "https://get.helm.sh/helm-v${version}-linux-amd64.tar.gz"
+          tarball_binary_path: "*/${binary}"
+          smoke_test: "${binary} version"
+      - name: Test unarchived install with colliding workspace file
+        uses: ./
+        with:
+          binary: jq
+          version: "1.7.1"
+          download_url: "https://github.com/jqlang/jq/releases/download/jq-${version}/jq-linux-amd64"
+          smoke_test: "${binary} --version"
+      - name: Cleanup colliding workspace entries
+        if: always()
+        run: rm -rf helm jq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Extract downloaded binaries into a unique directory under `RUNNER_TEMP`
+  instead of the workspace, so the action no longer fails with
+  `mkdir: cannot create directory 'X': File exists` when a workspace file or
+  directory has the same name as the binary being installed
+  ([#334](https://github.com/giantswarm/install-binary-action/issues/334)).
+
 ## [4.0.0] - 2025-12-12
 
 ### Changed

--- a/dist/index.js
+++ b/dist/index.js
@@ -30559,8 +30559,12 @@ var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: external "path"
 const external_path_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("path");
+;// CONCATENATED MODULE: external "fs"
+const external_fs_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("fs");
 ;// CONCATENATED MODULE: external "os"
 const external_os_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("os");
+;// CONCATENATED MODULE: external "process"
+const external_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("process");
 ;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/utils.js
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -30691,8 +30695,6 @@ function escapeProperty(s) {
 //# sourceMappingURL=command.js.map
 ;// CONCATENATED MODULE: external "crypto"
 const external_crypto_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("crypto");
-;// CONCATENATED MODULE: external "fs"
-const external_fs_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("fs");
 ;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/file-command.js
 // For internal use, subject to change.
 // We use any as a valid input type
@@ -34310,6 +34312,9 @@ function _unique(values) {
 
 
 
+
+
+
 const run = async () => {
   try {
     const binary = getInput('binary');
@@ -34345,8 +34350,8 @@ const run = async () => {
   }
 }
 
-const getUnTarCommand = (name, path, stripComponents, wildcard, binaryNewName) => {
-  let command = `tar -C ${name} -xzvf ${path} --strip-components ${stripComponents} --wildcards ${wildcard}`;
+const getUnTarCommand = (extractDir, path, stripComponents, wildcard, binaryNewName) => {
+  let command = `tar -C ${extractDir} -xzvf ${path} --strip-components ${stripComponents} --wildcards ${wildcard}`;
   if (binaryNewName) {
     command += ` --transform=s/${wildcard}/${binaryNewName}/`;
   }
@@ -34361,18 +34366,24 @@ const installTool = async (name, version, url, stripComponents, wildcard, binary
   }
 
   const path = await downloadTool(url);
-  await exec_exec(`mkdir ${name}`);
+
+  // Extract into a unique directory under RUNNER_TEMP (or the OS temp dir
+  // When running outside GitHub Actions) so the binary name cannot collide
+  // With files or directories that already exist in the workspace.
+  const tempRoot = external_process_namespaceObject.env.RUNNER_TEMP || external_os_namespaceObject.tmpdir();
+  const extractDir = await external_fs_namespaceObject.promises.mkdtemp(external_path_namespaceObject.join(tempRoot, 'install-binary-'));
 
   if (external_path_namespaceObject.extname(url) === '') {
-    // If there is not extension, assume this is an unarchived binary.
-    await exec_exec(`mv "${path}" "${name}/${name}"`);
-    await exec_exec(`chmod +x "${name}/${name}"`);
+    // If there is no extension, assume this is an unarchived binary.
+    const destination = external_path_namespaceObject.join(extractDir, name);
+    await exec_exec(`mv "${path}" "${destination}"`);
+    await exec_exec(`chmod +x "${destination}"`);
   } else {
-    const unTarCommand = getUnTarCommand(name, path, stripComponents, wildcard, binaryNewName);
+    const unTarCommand = getUnTarCommand(extractDir, path, stripComponents, wildcard, binaryNewName);
     await exec_exec(`${unTarCommand}`);
   }
 
-  cachedPath = await cacheDir(name, name, version);
+  cachedPath = await cacheDir(extractDir, name, version);
   addPath(cachedPath);
 }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 import paths from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import process from 'process';
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as tc from '@actions/tool-cache';
@@ -38,8 +41,8 @@ const run = async () => {
   }
 }
 
-const getUnTarCommand = (name, path, stripComponents, wildcard, binaryNewName) => {
-  let command = `tar -C ${name} -xzvf ${path} --strip-components ${stripComponents} --wildcards ${wildcard}`;
+const getUnTarCommand = (extractDir, path, stripComponents, wildcard, binaryNewName) => {
+  let command = `tar -C ${extractDir} -xzvf ${path} --strip-components ${stripComponents} --wildcards ${wildcard}`;
   if (binaryNewName) {
     command += ` --transform=s/${wildcard}/${binaryNewName}/`;
   }
@@ -54,18 +57,24 @@ const installTool = async (name, version, url, stripComponents, wildcard, binary
   }
 
   const path = await tc.downloadTool(url);
-  await exec.exec(`mkdir ${name}`);
+
+  // Extract into a unique directory under RUNNER_TEMP (or the OS temp dir
+  // When running outside GitHub Actions) so the binary name cannot collide
+  // With files or directories that already exist in the workspace.
+  const tempRoot = process.env.RUNNER_TEMP || os.tmpdir();
+  const extractDir = await fs.mkdtemp(paths.join(tempRoot, 'install-binary-'));
 
   if (paths.extname(url) === '') {
-    // If there is not extension, assume this is an unarchived binary.
-    await exec.exec(`mv "${path}" "${name}/${name}"`);
-    await exec.exec(`chmod +x "${name}/${name}"`);
+    // If there is no extension, assume this is an unarchived binary.
+    const destination = paths.join(extractDir, name);
+    await exec.exec(`mv "${path}" "${destination}"`);
+    await exec.exec(`chmod +x "${destination}"`);
   } else {
-    const unTarCommand = getUnTarCommand(name, path, stripComponents, wildcard, binaryNewName);
+    const unTarCommand = getUnTarCommand(extractDir, path, stripComponents, wildcard, binaryNewName);
     await exec.exec(`${unTarCommand}`);
   }
 
-  cachedPath = await tc.cacheDir(name, name, version);
+  cachedPath = await tc.cacheDir(extractDir, name, version);
   core.addPath(cachedPath);
 }
 


### PR DESCRIPTION
## Summary

`install-binary-action` extracted downloaded binaries into a directory named after the binary (e.g. `helm`) **inside the GitHub Actions workspace**. When the checked-out repository already contained a file or directory with the same name -- which is common for repos that ship helm charts under `helm/` -- `mkdir helm` failed:

```
/usr/bin/mkdir: cannot create directory 'helm': File exists
##[error]The process '/usr/bin/mkdir' failed with exit code 1
```

This broke `pre-commit` CI in `mcp-kubernetes`, `muster`, `llm-testing`, `mcp-prometheus`, `klaus`, and other repos. Eight PRs in the latest marge sweep had to be admin-merged because of this single bug, and three more in today's sweep ([klaus#217](https://github.com/giantswarm/klaus/pull/217), [mcp-kubernetes#367](https://github.com/giantswarm/mcp-kubernetes/pull/367), [muster#567](https://github.com/giantswarm/muster/pull/567)).

## Fix

Extract into a unique directory created via `fs.mkdtemp` under `RUNNER_TEMP` (with the OS temp dir as a fallback for local runs). The binary name can never collide with workspace contents because the destination path is freshly generated for each invocation.

The cache step now passes the unique extraction directory to `tc.cacheDir`, which preserves the existing behaviour of caching the binary under the tool name.

## Test plan

- [x] `yarn lint` passes
- [x] `yarn dist` produces a clean diff (`dist/index.js` is up to date)
- [x] Local smoke test confirms `fs.mkdtemp` writes outside the workspace and leaves workspace contents untouched
- [x] CI workflow now includes a regression test that pre-creates `helm/` (directory) and `jq` (file) in the workspace, then invokes the action with `binary: helm` (tarball install) and `binary: jq` (unarchived install). Both must succeed.

## Acceptance criteria from #334

- [x] The action succeeds even when a file or directory with the binary name exists in the workspace
- [x] No regressions in the normal (no collision) case -- all existing test cases retained
- [x] Test coverage for the collision scenario added in `.github/workflows/test.yaml`

Closes #334

Made with [Cursor](https://cursor.com)