### PR TITLE
test: end-to-end coverage for central pre-commit install steps

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,3 +94,36 @@ jobs:
       - name: Cleanup colliding workspace entries
         if: always()
         run: rm -rf helm jq
+
+      # End-to-end coverage of the install steps used in the central
+      # pre-commit workflow at giantswarm/github/workflows/zz_generated.pre-commit.yaml.
+      # These tarballs ship the binary at the archive root (no subdirectory),
+      # so tarball_binary_path must not contain a wildcard/slash. The
+      # helm-values-schema-json archive additionally names the binary
+      # "schema", so binary_new_name must be supplied as a literal (inputs
+      # other than download_url/tarball_binary_path are NOT template-expanded).
+      - name: Test install of helm-docs (flat tarball, no rename)
+        uses: ./
+        with:
+          binary: helm-docs
+          version: "1.14.2"
+          download_url: "https://github.com/norwoodj/helm-docs/releases/download/v${version}/helm-docs_${version}_Linux_x86_64.tar.gz"
+          tarball_binary_path: "${binary}"
+          smoke_test: "${binary} --version"
+      - name: Verify helm-docs is on PATH
+        run: |
+          which helm-docs
+          helm-docs --version
+      - name: Test install of helm-values-schema-json (flat tarball, rename schema -> helm-schema)
+        uses: ./
+        with:
+          binary: helm-schema
+          version: "2.3.1"
+          download_url: "https://github.com/losisin/helm-values-schema-json/releases/download/v${version}/helm-values-schema-json_${version}_linux_amd64.tgz"
+          tarball_binary_path: "schema"
+          binary_new_name: "helm-schema"
+          smoke_test: "${binary} version"
+      - name: Verify helm-schema is on PATH
+        run: |
+          which helm-schema
+          helm-schema version


### PR DESCRIPTION
## Summary

Add regression test steps that install `helm-docs` and `helm-values-schema-json` exactly the way the central pre-commit workflow does (giantswarm/github/workflows/zz_generated.pre-commit.yaml), plus `which` + smoke-invocation checks to confirm each binary lands on PATH with the expected name.

## Why

Several recent regressions (mkdir collision #334, stale download URLs, wrong tarball layout, \`\${binary}\` being passed as literal to \`tar --transform\`) only surfaced after Align files pushed broken workflows into every consumer repo. Keeping the scenarios the central workflow depends on under CI here means future breakage is caught on this PR instead of fanning out to dozens of teams.

## Covered scenarios

- **helm-docs**: flat tarball, binary name matches — \`tarball_binary_path: "\${binary}"\`
- **helm-values-schema-json** -> **helm-schema**: flat tarball, binary named \`schema\` inside archive — \`tarball_binary_path: "schema"\`, \`binary_new_name: "helm-schema"\` (literal, because \`binary_new_name\` is **not** template-expanded and a \`\${binary}\` value would be passed through to \`tar --transform\` and treated literally by sed).

## Test plan

CI is green: https://github.com/giantswarm/install-binary-action/actions/runs/24572448713