### PR TITLE
Apply template substitution to binary_new_name

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,10 +98,7 @@ jobs:
       # End-to-end coverage of the install steps used in the central
       # pre-commit workflow at giantswarm/github/workflows/zz_generated.pre-commit.yaml.
       # These tarballs ship the binary at the archive root (no subdirectory),
-      # so tarball_binary_path must not contain a wildcard/slash. The
-      # helm-values-schema-json archive additionally names the binary
-      # "schema", so binary_new_name must be supplied as a literal (inputs
-      # other than download_url/tarball_binary_path are NOT template-expanded).
+      # so tarball_binary_path must not contain a wildcard/slash.
       - name: Test install of helm-docs (flat tarball, no rename)
         uses: ./
         with:
@@ -114,14 +111,17 @@ jobs:
         run: |
           which helm-docs
           helm-docs --version
-      - name: Test install of helm-values-schema-json (flat tarball, rename schema -> helm-schema)
+      # Regression test for https://github.com/giantswarm/install-binary-action/issues/339:
+      # binary_new_name must support the same ${binary}/${version} template
+      # substitution as download_url, tarball_binary_path, and smoke_test.
+      - name: Test install of helm-values-schema-json (templated binary_new_name)
         uses: ./
         with:
           binary: helm-schema
           version: "2.3.1"
           download_url: "https://github.com/losisin/helm-values-schema-json/releases/download/v${version}/helm-values-schema-json_${version}_linux_amd64.tgz"
           tarball_binary_path: "schema"
-          binary_new_name: "helm-schema"
+          binary_new_name: "${binary}"
           smoke_test: "${binary} version"
       - name: Verify helm-schema is on PATH
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Apply `${binary}` / `${version}` template substitution to `binary_new_name`,
+  matching the behaviour already documented for `download_url`,
+  `tarball_binary_path`, and `smoke_test`
+  ([#339](https://github.com/giantswarm/install-binary-action/issues/339)).
+
 ## [4.0.1] - 2026-04-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ template format. Templated variables are `${binary}` and `${version}`.
 
 ## `binary_new_name`
 
-**Optional.** Name of the binary once is uncompressed and installed in the selected directory.
+**Optional.** Name of the binary once is uncompressed and installed in the
+selected directory. Can be in template format. Templated variables are
+`${binary}` and `${version}`.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: '${binary} version'
   binary_new_name:
-    description: 'Name of the binary once is installed. E.g. "aws"'
+    description: 'Name of the binary once is installed. E.g. "aws". Available variables are ${binary} and ${version}.'
     required: false
 outputs: {}
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -34319,7 +34319,7 @@ const run = async () => {
   try {
     const binary = getInput('binary');
     const version = getInput('version');
-    const binaryNewName = getInput('binary_new_name');
+    let binaryNewName = getInput('binary_new_name');
     let downloadURL = getInput('download_url');
     let tarballBinaryPath = getInput('tarball_binary_path');
     let smokeTest = getInput('smoke_test');
@@ -34332,6 +34332,7 @@ const run = async () => {
     downloadURL = fillTemplate(downloadURL);
     tarballBinaryPath = fillTemplate(tarballBinaryPath)
     smokeTest = fillTemplate(smokeTest);
+    binaryNewName = fillTemplate(binaryNewName);
 
     info(`binary:               ${binary}`);
     if (binaryNewName) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const run = async () => {
   try {
     const binary = core.getInput('binary');
     const version = core.getInput('version');
-    const binaryNewName = core.getInput('binary_new_name');
+    let binaryNewName = core.getInput('binary_new_name');
     let downloadURL = core.getInput('download_url');
     let tarballBinaryPath = core.getInput('tarball_binary_path');
     let smokeTest = core.getInput('smoke_test');
@@ -23,6 +23,7 @@ const run = async () => {
     downloadURL = fillTemplate(downloadURL);
     tarballBinaryPath = fillTemplate(tarballBinaryPath)
     smokeTest = fillTemplate(smokeTest);
+    binaryNewName = fillTemplate(binaryNewName);
 
     core.info(`binary:               ${binary}`);
     if (binaryNewName) {


### PR DESCRIPTION
## Summary

`binary_new_name` was the only string-template input the action did **not** template-substitute. `download_url`, `tarball_binary_path`, and `smoke_test` all expand `\${binary}` / `\${version}`; `binary_new_name` was read raw and fed into `tar --transform=s/<wildcard>/<value>/`. Callers passing `binary_new_name: \"\${binary}\"` got the literal text and the renamed binary became `\${binary}`, so subsequent steps couldn't resolve it on PATH.

This was the root cause of the `helm-schema` pre-commit failures we worked around in [giantswarm/github#5082](https://github.com/giantswarm/github/pull/5082) (and downstream copies). With this change the original template form works as documented and the workaround can be reverted.

## Changes

- `index.js` / `dist/index.js`: pipe `binaryNewName` through the existing `fillTemplate` helper.
- `action.yml`: document the supported template variables on the input.
- `README.md`: document the supported template variables.
- `.github/workflows/test.yaml`: rewrite the `helm-values-schema-json` regression test to use the templated form (`binary_new_name: \"\${binary}\"`) so the contract is enforced in CI.
- `CHANGELOG.md`: Unreleased entry.

## Test plan

- [x] `yarn lint` passes
- [x] `yarn dist` is clean (`dist/index.js` regenerated and committed)
- [x] CI workflow exercises a templated `binary_new_name` end-to-end and verifies the binary resolves on PATH

## Acceptance criteria from #339

- [x] `binary_new_name` accepts and expands `\${binary}` / `\${version}`
- [x] Documented in README and action.yml
- [x] Smoke test exercises a templated `binary_new_name`

Closes #339

Made with [Cursor](https://cursor.com)